### PR TITLE
Update sight to v0.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sight-extension"
-version = "0.1.24"
+version = "0.1.25"
 edition = "2021"
 license = "GPL-3.0"
 description = "Zed extension for Stata language support using the Sight LSP"

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "stata"
 name = "Stata"
 description = "Stata language support for Zed"
-version = "0.1.24"
+version = "0.1.25"
 schema_version = 1
 authors = ["Jonathan Marc Bearak"]
 repository = "https://github.com/jbearak/zed-stata"
@@ -12,7 +12,7 @@ capabilities = []
 
 [lib]
 kind = "Rust"
-version = "0.1.24"
+version = "0.1.25"
 
 [grammars.stata]
 repository = "https://github.com/jbearak/tree-sitter-stata"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 use zed_extension_api::{self as zed, DownloadedFileType, Result};
 
-const SERVER_VERSION: &str = "v0.1.25";
+const SERVER_VERSION: &str = "v0.3.1";
 const GITHUB_RELEASE_URL: &str = "https://github.com/jbearak/sight/releases/download";
 
 struct SightExtension {

--- a/tools/dev/dev-setup-windows.ps1
+++ b/tools/dev/dev-setup-windows.ps1
@@ -78,8 +78,8 @@ $script:Checksums = @{
     # Tree-sitter-stata grammar WASM v0.1.0
     TreeSitterGrammar = "357d74471e1c8e316805f882c4b942438ee1c54b5f23687ac001d710b826a237"
 
-    # Sight language server v0.1.25
-    SightServer = "694e370a32b30c75b7785d2433e719e44708992fc782533477b5a1acd2210205"
+    # Sight language server v0.3.1
+    SightServer = "728327346239ca4698d47b9cc7b1595995336e2c0178f6481c46fa776e46b5a8"
 }
 
 function Test-FileChecksum {
@@ -645,7 +645,7 @@ function Download-LanguageServerForDev {
     # but downloads go to Zed's work directory. We need to copy/download the server to the repo
     # so it can be found during dev testing.
 
-    $serverVersion = "v0.1.25"
+    $serverVersion = "v0.3.1"
     $serverDir = Join-Path $RepoRoot "sight-node-$serverVersion"
     $serverScript = Join-Path $serverDir "sight-server.js"
 


### PR DESCRIPTION
## Summary

This PR updates the sight language server to **v0.3.1**.

### Changes
- SERVER_VERSION: v0.1.25 -> v0.3.1
- Extension version: 0.1.24 -> 0.1.25
- Rebuilt extension.wasm
- Updated dev-setup-windows.ps1 SightServer checksum

### Testing Checklist
- [ ] Install extension in Zed
- [ ] Open a .do file and verify LSP starts
- [ ] Check hover/go-to-definition

---
*Automated PR from update-sight-version workflow.*

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/zed-stata/pull/37" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
