### PR TITLE
Update docs

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,7 @@
+{
+  "languages": {
+    "Stata": {
+      "document_symbols": "on"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -29,6 +29,29 @@ Install from the Zed extension marketplace by searching for "Sight" or "Stata".
 
 Syntax highlighting, completions, and diagnostics will work immediately once you open a ".do" file.
 
+## Outline Configuration
+
+Zed can populate the outline and breadcrumbs from Sight's LSP `textDocument/documentSymbol` response instead of the tree-sitter outline query.
+
+Add the following to your Zed user settings:
+
+```json
+{
+  "languages": {
+    "Stata": {
+      "document_symbols": "on"
+    }
+  }
+}
+```
+
+You can add this in either of these places:
+
+- User settings (`~/.config/zed/settings.json` on macOS/Linux, `%APPDATA%\\Zed\\settings.json` on Windows) to enable LSP-backed outline for all Stata files
+- Project settings (`.zed/settings.json` in a repository) to enable it only for that project
+
+Without this setting, Zed uses the tree-sitter outline query, which is currently much narrower than Sight's document symbols.
+
 ## Send to Stata (Optional)
 
 Execute Stata code directly from Zed with keyboard shortcuts. Works with both the Stata application and terminal sessions.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Without this setting, Zed uses the tree-sitter outline query, which is currently
 Execute Stata code directly from Zed with keyboard shortcuts. Works with both the Stata application and terminal sessions.
 
 > [!NOTE]
-> **Why a separate install?** Zed extensions can't register custom keybindings or tasks—those must live in user config files. The send-to-stata functionality requires both, so it can't be bundled into the extension itself.
+> **Why a separate install?** Zed extensions can provide tasks, but custom keybindings still have to live in user config, and in practice users need their own copies of the tasks for those bindings. On Windows, the workflow also depends on the native `send-to-stata.exe` binary. The installer sets up the required script or executable plus the user-owned task and keybinding configuration.
 
 See [tools/send-to-stata/README.md](tools/send-to-stata/README.md) for full documentation, configuration options, and troubleshooting.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Add the following to your Zed user settings:
 
 You can add this in either of these places:
 
-- User settings (`~/.config/zed/settings.json` on macOS/Linux, `%APPDATA%\\Zed\\settings.json` on Windows) to enable LSP-backed outline for all Stata files
+- User settings (`~/.config/zed/settings.json` on macOS/Linux, `%APPDATA%\Zed\settings.json` on Windows) to enable LSP-backed outline for all Stata files
+
 - Project settings (`.zed/settings.json` in a repository) to enable it only for that project
 
 Without this setting, Zed uses the tree-sitter outline query, which is currently much narrower than Sight's document symbols.


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/zed-stata/pull/42" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for enabling Stata outline/breadcrumb functionality using document symbols in Zed editor.

* **Documentation**
  * Added configuration guide explaining how to enable Stata document symbols in user settings.
  * Updated Send-to-Stata documentation with improved Windows-specific workflow details and installer information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->