### PR TITLE
Rename Zed extension references to Stata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,7 +167,7 @@ Zed does not warn about this misconfiguration - the extension loads but the LSP 
 
 ```bash
 cargo build --release --target wasm32-wasip1
-cp target/wasm32-wasip1/release/sight_extension.wasm extension.wasm
+cp target/wasm32-wasip1/release/zed_stata.wasm extension.wasm
 ```
 
 Or use the dev setup script:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "sight-extension"
-version = "0.1.26"
+name = "zed-stata"
+version = "0.5.0"
 edition = "2021"
 license = "GPL-3.0"
-description = "Zed extension for Stata language support using the Sight LSP"
+description = "Zed extension for Stata language support"
 repository = "https://github.com/jbearak/zed-stata"
 
 [lib]

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -82,7 +82,7 @@ zed-stata/
 ```bash
 # macOS/Linux
 cargo build --release --target wasm32-wasip1
-cp target/wasm32-wasip1/release/sight_extension.wasm extension.wasm
+cp target/wasm32-wasip1/release/zed_stata.wasm extension.wasm
 
 # Windows (via dev-setup-windows.ps1)
 .\tools\dev\dev-setup-windows.ps1 -Yes

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -138,13 +138,21 @@ ln -s $(pwd) ~/.local/share/zed/extensions/installed/stata
 
 Use the version bump script:
 ```bash
-./tools/dev/update_version.sh 0.1.18
+./tools/dev/update_version.sh 0.5.1
 ```
 
 This updates:
-- `extension.toml` version
-- `Cargo.toml` version
+- `Cargo.toml` `[package].version`
+- top-level `extension.toml` `version`
 - Creates a git commit and tag
+
+It does **not** update `extension.toml [lib].version`. That field tracks the Zed
+extension API version and should stay aligned with `Cargo.toml`
+`zed_extension_api`.
+
+Guardrails:
+- `./tools/dev/validate.sh --release-version` checks that `Cargo.toml [package].version` and top-level `extension.toml version` match
+- `./tools/dev/validate.sh --api-version` checks that `extension.toml [lib].version` matches `Cargo.toml zed_extension_api`
 
 ### Updating Sight LSP Version
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A [Zed](https://zed.dev) extension providing support for the Stata statistical p
 
 ## Installation
 
-Install from the Zed extension marketplace by searching for "Sight" or "Stata".
+Install from the Zed extension marketplace by searching for "Stata".
 
 Syntax highlighting, completions, and diagnostics will work immediately once you open a ".do" file.
 

--- a/extension.toml
+++ b/extension.toml
@@ -12,7 +12,7 @@ capabilities = []
 
 [lib]
 kind = "Rust"
-version = "0.1.26"
+version = "0.7.0"
 
 [grammars.stata]
 repository = "https://github.com/jbearak/tree-sitter-stata"

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "stata"
 name = "Stata"
 description = "Stata language support for Zed"
-version = "0.1.26"
+version = "0.5.0"
 schema_version = 1
 authors = ["Jonathan Marc Bearak"]
 repository = "https://github.com/jbearak/zed-stata"

--- a/install-grammar.ps1
+++ b/install-grammar.ps1
@@ -48,7 +48,7 @@ if (Test-Path $grammarSrcDir)
 }
 
 # Also install to Zed extensions directory if it exists
-$zedExtDir = Join-Path $env:LOCALAPPDATA 'Zed\extensions\installed\sight'
+$zedExtDir = Join-Path $env:LOCALAPPDATA 'Zed\extensions\installed\stata'
 if (Test-Path $zedExtDir)
 {
     $zedGrammarsDir = Join-Path $zedExtDir 'grammars'

--- a/tests/config_parser.bats
+++ b/tests/config_parser.bats
@@ -65,11 +65,12 @@ EOF
 create_extension_toml() {
     local revision="$1"
     local lib_version="${2:-0.7.0}"
+    local release_version="${3:-0.5.0}"
     cat > "$TEMP_DIR/extension.toml" << EOF
 id = "stata"
 name = "Stata"
 description = "Language support for Stata using LSP"
-version = "0.1.26"
+version = "$release_version"
 schema_version = 1
 authors = ["Jonathan Marc Bearak"]
 repository = "https://github.com/jbearak/zed-stata"
@@ -91,10 +92,11 @@ EOF
 # Helper: Create a Cargo.toml with a specific zed_extension_api version
 create_cargo_toml() {
     local api_version="${1:-0.7.0}"
+    local package_version="${2:-0.5.0}"
     cat > "$TEMP_DIR/Cargo.toml" << EOF
 [package]
 name = "zed-stata"
-version = "0.5.0"
+version = "$package_version"
 edition = "2021"
 
 [lib]
@@ -315,7 +317,7 @@ EOF
     cat > "$TEMP_DIR/extension.toml" << 'EOF'
 id = "stata"
 name = "Stata"
-version = "0.1.26"
+version = "0.5.0"
 
 [lib]
 kind = "Rust"
@@ -333,7 +335,7 @@ EOF
     cat > "$TEMP_DIR/extension.toml" << 'EOF'
 id = "stata"
 name = "Stata"
-version = "0.1.26"
+version = "0.5.0"
 
 [grammars.stata]
 repository = "https://github.com/jbearak/tree-sitter-stata"
@@ -351,7 +353,7 @@ EOF
     cat > "$TEMP_DIR/extension.toml" << EOF
 id = "stata"
 name = "Stata"
-version = "0.1.26"
+version = "0.5.0"
 
 [grammars.other]
 repository = "https://github.com/example/tree-sitter-other"
@@ -373,14 +375,91 @@ EOF
 }
 
 #######################################
-# Property 3: API version alignment consistency
+# Property 3: Release version alignment consistency
+# For any valid extension.toml top-level version and Cargo.toml [package]
+# version, the validator SHALL extract both values correctly and report
+# whether they match exactly.
+#######################################
+
+@test "Property 3: extract manifest release version from top-level version" {
+    create_extension_toml "872da1d652dd32cc871ea4a3c3f84bdea7c68c8c" "0.7.0" "0.5.0"
+
+    local extracted
+    extracted=$(extract_manifest_release_version)
+
+    [ "$extracted" = "0.5.0" ]
+}
+
+@test "Property 3: extract cargo package version from Cargo.toml" {
+    create_cargo_toml "0.7.0" "0.5.0"
+
+    local extracted
+    extracted=$(extract_cargo_package_version)
+
+    [ "$extracted" = "0.5.0" ]
+}
+
+@test "Property 3: release version alignment succeeds when versions match" {
+    create_extension_toml "872da1d652dd32cc871ea4a3c3f84bdea7c68c8c" "0.7.0" "0.5.0"
+    create_cargo_toml "0.7.0" "0.5.0"
+
+    run validate_release_version_alignment
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Release versions are aligned"* ]]
+}
+
+@test "Property 3: release version alignment fails on mismatch" {
+    create_extension_toml "872da1d652dd32cc871ea4a3c3f84bdea7c68c8c" "0.7.0" "0.1.26"
+    create_cargo_toml "0.7.0" "0.5.0"
+
+    run validate_release_version_alignment
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"extension.toml version is 0.1.26 but Cargo.toml [package].version is 0.5.0"* ]]
+}
+
+@test "Property 3: error on missing top-level version" {
+    cat > "$TEMP_DIR/extension.toml" << 'EOF'
+id = "stata"
+name = "Stata"
+
+[lib]
+kind = "Rust"
+version = "0.7.0"
+EOF
+
+    run extract_manifest_release_version
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"ERROR: top-level version not found"* ]]
+}
+
+@test "Property 3: error on missing Cargo package version" {
+    cat > "$TEMP_DIR/Cargo.toml" << 'EOF'
+[package]
+name = "zed-stata"
+edition = "2021"
+
+[dependencies]
+zed_extension_api = "0.7.0"
+EOF
+
+    run extract_cargo_package_version
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"ERROR: [package] version not found"* ]]
+}
+
+#######################################
+# Property 4: API version alignment consistency
 # For any valid extension.toml [lib] version and Cargo.toml zed_extension_api
 # dependency, the validator SHALL extract both values correctly and report
 # whether they match exactly.
 # **Validates: Requirements 6.3**
 #######################################
 
-@test "Property 3: extract manifest lib version from [lib] section" {
+@test "Property 4: extract manifest lib version from [lib] section" {
     create_extension_toml "872da1d652dd32cc871ea4a3c3f84bdea7c68c8c" "0.7.0"
 
     local extracted
@@ -389,7 +468,7 @@ EOF
     [ "$extracted" = "0.7.0" ]
 }
 
-@test "Property 3: extract zed_extension_api version from Cargo.toml" {
+@test "Property 4: extract zed_extension_api version from Cargo.toml" {
     create_cargo_toml "0.7.0"
 
     local extracted
@@ -398,7 +477,7 @@ EOF
     [ "$extracted" = "0.7.0" ]
 }
 
-@test "Property 3: api version alignment succeeds when versions match" {
+@test "Property 4: api version alignment succeeds when versions match" {
     create_extension_toml "872da1d652dd32cc871ea4a3c3f84bdea7c68c8c" "0.7.0"
     create_cargo_toml "0.7.0"
 
@@ -408,7 +487,7 @@ EOF
     [[ "$output" == *"API versions are aligned"* ]]
 }
 
-@test "Property 3: api version alignment fails on mismatch" {
+@test "Property 4: api version alignment fails on mismatch" {
     create_extension_toml "872da1d652dd32cc871ea4a3c3f84bdea7c68c8c" "0.1.26"
     create_cargo_toml "0.7.0"
 
@@ -418,11 +497,11 @@ EOF
     [[ "$output" == *"extension.toml [lib].version is 0.1.26 but Cargo.toml zed_extension_api is 0.7.0"* ]]
 }
 
-@test "Property 3: error on missing lib version in [lib] section" {
+@test "Property 4: error on missing lib version in [lib] section" {
     cat > "$TEMP_DIR/extension.toml" << 'EOF'
 id = "stata"
 name = "Stata"
-version = "0.1.26"
+version = "0.5.0"
 
 [lib]
 kind = "Rust"
@@ -434,7 +513,7 @@ EOF
     [[ "$output" == *"ERROR: [lib] version not found"* ]]
 }
 
-@test "Property 3: error on missing zed_extension_api dependency" {
+@test "Property 4: error on missing zed_extension_api dependency" {
     cat > "$TEMP_DIR/Cargo.toml" << 'EOF'
 [package]
 name = "zed-stata"

--- a/tests/config_parser.bats
+++ b/tests/config_parser.bats
@@ -7,8 +7,9 @@ load test_helpers
 #
 # Tests Property 1: Version extraction consistency
 # Tests Property 2: Revision extraction consistency
+# Tests Property 3: API version alignment consistency
 #
-# **Validates: Requirements 1.1, 6.1, 6.2**
+# **Validates: Requirements 1.1, 6.1, 6.2, 6.3**
 
 # Setup - load test helpers and source validation functions
 setup() {
@@ -26,6 +27,7 @@ setup() {
     # Override SCRIPT_DIR to use our temp directory
     sed -i.bak "s|SCRIPT_DIR=.*|SCRIPT_DIR=\"$TEMP_DIR\"|" "$tmp_source"
     source "$tmp_source"
+    REPO_ROOT="$TEMP_DIR"
     rm -f "$tmp_source" "$tmp_source.bak"
 }
 
@@ -62,18 +64,19 @@ EOF
 # Helper: Create an extension.toml file with a specific revision
 create_extension_toml() {
     local revision="$1"
+    local lib_version="${2:-0.7.0}"
     cat > "$TEMP_DIR/extension.toml" << EOF
 id = "stata"
 name = "Stata"
 description = "Language support for Stata using LSP"
-version = "0.1.10"
+version = "0.1.26"
 schema_version = 1
 authors = ["Jonathan Marc Bearak"]
 repository = "https://github.com/jbearak/zed-stata"
 
 [lib]
 kind = "Rust"
-version = "0.7.0"
+version = "$lib_version"
 
 [grammars.stata]
 repository = "https://github.com/jbearak/tree-sitter-stata"
@@ -81,7 +84,24 @@ rev = "$revision"
 
 [language_servers.sight]
 name = "Sight"
-language = "Stata"
+languages = ["Stata"]
+EOF
+}
+
+# Helper: Create a Cargo.toml with a specific zed_extension_api version
+create_cargo_toml() {
+    local api_version="${1:-0.7.0}"
+    cat > "$TEMP_DIR/Cargo.toml" << EOF
+[package]
+name = "zed-stata"
+version = "0.5.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+zed_extension_api = "$api_version"
 EOF
 }
 
@@ -295,7 +315,7 @@ EOF
     cat > "$TEMP_DIR/extension.toml" << 'EOF'
 id = "stata"
 name = "Stata"
-version = "0.1.10"
+version = "0.1.26"
 
 [lib]
 kind = "Rust"
@@ -313,7 +333,7 @@ EOF
     cat > "$TEMP_DIR/extension.toml" << 'EOF'
 id = "stata"
 name = "Stata"
-version = "0.1.10"
+version = "0.1.26"
 
 [grammars.stata]
 repository = "https://github.com/jbearak/tree-sitter-stata"
@@ -331,7 +351,7 @@ EOF
     cat > "$TEMP_DIR/extension.toml" << EOF
 id = "stata"
 name = "Stata"
-version = "0.1.10"
+version = "0.1.26"
 
 [grammars.other]
 repository = "https://github.com/example/tree-sitter-other"
@@ -350,4 +370,83 @@ EOF
     extracted=$(extract_grammar_revision)
     
     [ "$extracted" = "$revision" ]
+}
+
+#######################################
+# Property 3: API version alignment consistency
+# For any valid extension.toml [lib] version and Cargo.toml zed_extension_api
+# dependency, the validator SHALL extract both values correctly and report
+# whether they match exactly.
+# **Validates: Requirements 6.3**
+#######################################
+
+@test "Property 3: extract manifest lib version from [lib] section" {
+    create_extension_toml "872da1d652dd32cc871ea4a3c3f84bdea7c68c8c" "0.7.0"
+
+    local extracted
+    extracted=$(extract_manifest_lib_version)
+
+    [ "$extracted" = "0.7.0" ]
+}
+
+@test "Property 3: extract zed_extension_api version from Cargo.toml" {
+    create_cargo_toml "0.7.0"
+
+    local extracted
+    extracted=$(extract_zed_extension_api_version)
+
+    [ "$extracted" = "0.7.0" ]
+}
+
+@test "Property 3: api version alignment succeeds when versions match" {
+    create_extension_toml "872da1d652dd32cc871ea4a3c3f84bdea7c68c8c" "0.7.0"
+    create_cargo_toml "0.7.0"
+
+    run validate_api_version_alignment
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"API versions are aligned"* ]]
+}
+
+@test "Property 3: api version alignment fails on mismatch" {
+    create_extension_toml "872da1d652dd32cc871ea4a3c3f84bdea7c68c8c" "0.1.26"
+    create_cargo_toml "0.7.0"
+
+    run validate_api_version_alignment
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"extension.toml [lib].version is 0.1.26 but Cargo.toml zed_extension_api is 0.7.0"* ]]
+}
+
+@test "Property 3: error on missing lib version in [lib] section" {
+    cat > "$TEMP_DIR/extension.toml" << 'EOF'
+id = "stata"
+name = "Stata"
+version = "0.1.26"
+
+[lib]
+kind = "Rust"
+EOF
+
+    run extract_manifest_lib_version
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"ERROR: [lib] version not found"* ]]
+}
+
+@test "Property 3: error on missing zed_extension_api dependency" {
+    cat > "$TEMP_DIR/Cargo.toml" << 'EOF'
+[package]
+name = "zed-stata"
+version = "0.5.0"
+edition = "2021"
+
+[dependencies]
+serde = "1.0"
+EOF
+
+    run extract_zed_extension_api_version
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"ERROR: zed_extension_api dependency not found"* ]]
 }

--- a/tests/config_parser.bats
+++ b/tests/config_parser.bats
@@ -22,7 +22,7 @@ setup() {
     # Source the validation script functions (without running main)
     # Create a temporary file that sources validate.sh but doesn't run main
     local tmp_source=$(mktemp)
-    sed '/^main "\$@"$/d' "$PROJECT_DIR/validate.sh" > "$tmp_source"
+    sed '/^main "\$@"$/d' "$PROJECT_DIR/tools/dev/validate.sh" > "$tmp_source"
     # Override SCRIPT_DIR to use our temp directory
     sed -i.bak "s|SCRIPT_DIR=.*|SCRIPT_DIR=\"$TEMP_DIR\"|" "$tmp_source"
     source "$tmp_source"
@@ -63,13 +63,13 @@ EOF
 create_extension_toml() {
     local revision="$1"
     cat > "$TEMP_DIR/extension.toml" << EOF
-id = "sight"
-name = "Sight - Stata Language Server"
+id = "stata"
+name = "Stata"
 description = "Language support for Stata using LSP"
 version = "0.1.10"
 schema_version = 1
 authors = ["Jonathan Marc Bearak"]
-repository = "https://github.com/jbearak/sight-zed"
+repository = "https://github.com/jbearak/zed-stata"
 
 [lib]
 kind = "Rust"
@@ -293,8 +293,8 @@ EOF
 # Test: Error on missing grammars.stata section
 @test "Property 2: error on missing grammars.stata section" {
     cat > "$TEMP_DIR/extension.toml" << 'EOF'
-id = "sight"
-name = "Sight - Stata Language Server"
+id = "stata"
+name = "Stata"
 version = "0.1.10"
 
 [lib]
@@ -311,8 +311,8 @@ EOF
 # Test: Error on missing rev field in grammars.stata section
 @test "Property 2: error on missing rev field" {
     cat > "$TEMP_DIR/extension.toml" << 'EOF'
-id = "sight"
-name = "Sight - Stata Language Server"
+id = "stata"
+name = "Stata"
 version = "0.1.10"
 
 [grammars.stata]
@@ -329,8 +329,8 @@ EOF
 @test "Property 2: extract revision with multiple grammar sections" {
     local revision="872da1d652dd32cc871ea4a3c3f84bdea7c68c8c"
     cat > "$TEMP_DIR/extension.toml" << EOF
-id = "sight"
-name = "Sight - Stata Language Server"
+id = "stata"
+name = "Stata"
 version = "0.1.10"
 
 [grammars.other]

--- a/tests/test_helpers.sh
+++ b/tests/test_helpers.sh
@@ -198,8 +198,8 @@ create_temp_extension_toml() {
     local revision="$1"
     local tmpfile=$(mktemp)
     cat > "$tmpfile" << EOF
-id = "sight"
-name = "Sight - Stata Language Server"
+id = "stata"
+name = "Stata"
 version = "0.1.10"
 
 [grammars.stata]

--- a/tests/test_helpers.sh
+++ b/tests/test_helpers.sh
@@ -200,7 +200,7 @@ create_temp_extension_toml() {
     cat > "$tmpfile" << EOF
 id = "stata"
 name = "Stata"
-version = "0.1.26"
+version = "0.5.0"
 
 [grammars.stata]
 repository = "https://github.com/jbearak/tree-sitter-stata"

--- a/tests/test_helpers.sh
+++ b/tests/test_helpers.sh
@@ -200,7 +200,7 @@ create_temp_extension_toml() {
     cat > "$tmpfile" << EOF
 id = "stata"
 name = "Stata"
-version = "0.1.10"
+version = "0.1.26"
 
 [grammars.stata]
 repository = "https://github.com/jbearak/tree-sitter-stata"

--- a/tools/dev/README.md
+++ b/tools/dev/README.md
@@ -100,7 +100,7 @@ If you prefer to build manually without running the full setup:
 ```bash
 # Build extension WASM
 cargo build --release --target wasm32-wasip1
-cp target/wasm32-wasip1/release/sight_extension.wasm extension.wasm
+cp target/wasm32-wasip1/release/zed_stata.wasm extension.wasm
 
 # Build grammar (requires tree-sitter CLI)
 cd grammars/stata
@@ -112,7 +112,7 @@ tree-sitter build --wasm -o stata.wasm
 ```powershell
 # Build extension WASM (requires MSVC environment)
 cargo build --release --target wasm32-wasip2
-copy target\wasm32-wasip2\release\sight_extension.wasm extension.wasm
+copy target\wasm32-wasip2\release\zed_stata.wasm extension.wasm
 
 # Grammar must be downloaded (Windows cannot compile tree-sitter grammars)
 # The dev-setup-windows.ps1 script handles this automatically

--- a/tools/dev/README.md
+++ b/tools/dev/README.md
@@ -130,11 +130,11 @@ Or create a symlink manually:
 
 **macOS:**
 ```bash
-ln -s "$(pwd)" "$HOME/Library/Application Support/Zed/extensions/installed/sight"
+ln -s "$(pwd)" "$HOME/Library/Application Support/Zed/extensions/installed/stata"
 ```
 
 **Windows:**
-The setup script copies files to `%LOCALAPPDATA%\Zed\extensions\installed\sight\`
+The setup script copies files to `%LOCALAPPDATA%\Zed\extensions\installed\stata\`
 
 ## Checksum Update Scripts
 

--- a/tools/dev/dev-setup-macos.sh
+++ b/tools/dev/dev-setup-macos.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# dev-setup-macos.sh - Build and install Sight Zed extension for local development
+# dev-setup-macos.sh - Build and install the Stata Zed extension for local development
 #
 # Usage:
 #   ./dev-setup-macos.sh              Build extension, install symlink, run installers
@@ -132,7 +132,7 @@ uninstall_symlink() {
 # ============================================================================
 
 uninstall() {
-  echo "Uninstalling Sight Zed extension..."
+  echo "Uninstalling Stata Zed extension..."
   echo ""
   uninstall_symlink
   echo ""
@@ -144,7 +144,7 @@ uninstall() {
 install() {
   local skip_tools="${1:-false}"
 
-  echo "Setting up Sight Zed extension..."
+  echo "Setting up Stata Zed extension..."
   echo ""
   check_prerequisites
   build_extension
@@ -165,7 +165,7 @@ install() {
   "$REPO_ROOT/tools/jupyter-kernel/install-macos.sh" --quiet
   echo ""
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  echo "  Sight Zed extension setup complete!"
+  echo "  Stata Zed extension setup complete!"
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
   echo ""
   echo "  Extension:        Installed at $SYMLINK_PATH"

--- a/tools/dev/dev-setup-macos.sh
+++ b/tools/dev/dev-setup-macos.sh
@@ -85,7 +85,7 @@ build_extension() {
   echo "Building extension..."
   cd "$REPO_ROOT"
   cargo build --release --target wasm32-wasip1
-  cp "$REPO_ROOT/target/wasm32-wasip1/release/sight_extension.wasm" "$REPO_ROOT/extension.wasm"
+  cp "$REPO_ROOT/target/wasm32-wasip1/release/zed_stata.wasm" "$REPO_ROOT/extension.wasm"
   print_success "Built extension.wasm"
 }
 

--- a/tools/dev/dev-setup-macos.sh
+++ b/tools/dev/dev-setup-macos.sh
@@ -13,6 +13,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 ZED_EXT_DIR="$HOME/Library/Application Support/Zed/extensions/installed"
 SYMLINK_PATH="$ZED_EXT_DIR/stata"
+# Legacy symlink from the previous extension name; remove on install/uninstall
+# to prevent duplicate extension loading after the rename.
+LEGACY_SYMLINK_PATH="$ZED_EXT_DIR/sight"
 
 # Colors for output
 RED='\033[0;31m'
@@ -101,8 +104,20 @@ build_grammar() {
 # Symlink Installation
 # ============================================================================
 
+remove_legacy_symlink() {
+  if [[ -L "$LEGACY_SYMLINK_PATH" ]]; then
+    rm "$LEGACY_SYMLINK_PATH"
+    print_success "Removed legacy extension symlink at $LEGACY_SYMLINK_PATH"
+  elif [[ -e "$LEGACY_SYMLINK_PATH" ]]; then
+    print_warning "$LEGACY_SYMLINK_PATH exists but is not a symlink, skipping"
+  fi
+}
+
 install_symlink() {
   mkdir -p "$ZED_EXT_DIR"
+
+  # Clean up legacy symlink from previous extension name to avoid duplicate loads.
+  remove_legacy_symlink
 
   if [[ -L "$SYMLINK_PATH" ]]; then
     rm "$SYMLINK_PATH"
@@ -125,6 +140,9 @@ uninstall_symlink() {
   else
     print_warning "Extension symlink not found, skipping"
   fi
+
+  # Also clean up legacy symlink from previous extension name.
+  remove_legacy_symlink
 }
 
 # ============================================================================

--- a/tools/dev/dev-setup-windows.ps1
+++ b/tools/dev/dev-setup-windows.ps1
@@ -622,7 +622,7 @@ function Build-Extension {
     }
     if ($LASTEXITCODE -ne 0) { throw "cargo build failed." }
 
-    $builtWasm = Join-Path $RepoRoot 'target\wasm32-wasip2\release\sight_extension.wasm'
+    $builtWasm = Join-Path $RepoRoot 'target\wasm32-wasip2\release\zed_stata.wasm'
     if (-not (Test-Path $builtWasm)) {
         throw "Expected build output not found: $builtWasm"
     }

--- a/tools/dev/dev-setup-windows.ps1
+++ b/tools/dev/dev-setup-windows.ps1
@@ -664,7 +664,7 @@ function Download-LanguageServerForDev {
     }
 
     # First check if Zed already downloaded it to the work directory
-    $zedWorkDir = Join-Path $env:LOCALAPPDATA "Zed\extensions\work\sight\sight-node-$serverVersion"
+    $zedWorkDir = Join-Path $env:LOCALAPPDATA "Zed\extensions\work\stata\sight-node-$serverVersion"
     $zedServerScript = Join-Path $zedWorkDir "sight-server.js"
 
     if (Test-Path $zedServerScript) {
@@ -704,7 +704,7 @@ function Install-ZedExtension {
         throw "APPDATA is not set; cannot locate Zed configuration directory."
     }
 
-    $dest = Join-Path $InstallRoot 'sight'
+    $dest = Join-Path $InstallRoot 'stata'
     if (-not (Test-Path $InstallRoot)) {
         New-Item -ItemType Directory -Path $InstallRoot -Force | Out-Null
     }
@@ -746,7 +746,7 @@ function Install-ZedExtension {
 function Uninstall-ZedExtension {
     param([string]$InstallRoot)
 
-    $dest = Join-Path $InstallRoot 'sight'
+    $dest = Join-Path $InstallRoot 'stata'
     if (Test-Path $dest) {
         Remove-Item -Path $dest -Recurse -Force
         Write-Host "Removed extension directory: $dest"

--- a/tools/dev/dev-setup-windows.ps1
+++ b/tools/dev/dev-setup-windows.ps1
@@ -663,6 +663,14 @@ function Download-LanguageServerForDev {
         }
     }
 
+    # Clean up legacy work cache from the previous extension name so leftover
+    # work\sight\... trees don't confuse dev testing after the rename.
+    $legacyZedWorkDir = Join-Path $env:LOCALAPPDATA "Zed\extensions\work\sight\sight-node-$serverVersion"
+    if (Test-Path $legacyZedWorkDir) {
+        Remove-Item -Path $legacyZedWorkDir -Recurse -Force
+        Write-Host "Removed legacy Zed work cache: $legacyZedWorkDir" -ForegroundColor Yellow
+    }
+
     # First check if Zed already downloaded it to the work directory
     $zedWorkDir = Join-Path $env:LOCALAPPDATA "Zed\extensions\work\stata\sight-node-$serverVersion"
     $zedServerScript = Join-Path $zedWorkDir "sight-server.js"
@@ -709,6 +717,14 @@ function Install-ZedExtension {
         New-Item -ItemType Directory -Path $InstallRoot -Force | Out-Null
     }
 
+    # Remove legacy 'sight' install from the previous extension name to prevent
+    # duplicate registrations after the rename.
+    $legacyDest = Join-Path $InstallRoot 'sight'
+    if (Test-Path $legacyDest) {
+        Remove-Item -Path $legacyDest -Recurse -Force
+        Write-Host "Removed legacy extension directory: $legacyDest"
+    }
+
     if (Test-Path $dest) {
         Remove-Item -Path $dest -Recurse -Force
     }
@@ -752,6 +768,14 @@ function Uninstall-ZedExtension {
         Write-Host "Removed extension directory: $dest"
     } else {
         Write-Host "Extension directory not found (already removed): $dest"
+    }
+
+    # Also remove legacy 'sight' install from the previous extension name to prevent
+    # duplicate registrations after the rename.
+    $legacyDest = Join-Path $InstallRoot 'sight'
+    if (Test-Path $legacyDest) {
+        Remove-Item -Path $legacyDest -Recurse -Force
+        Write-Host "Removed legacy extension directory: $legacyDest"
     }
 }
 

--- a/tools/dev/update_version.sh
+++ b/tools/dev/update_version.sh
@@ -142,7 +142,7 @@ fi
 if command -v cargo &> /dev/null; then
     echo "Rebuilding WASM extension..."
     cargo build --release --target wasm32-wasip1
-    cp target/wasm32-wasip1/release/sight_extension.wasm extension.wasm
+    cp target/wasm32-wasip1/release/zed_stata.wasm extension.wasm
     echo "Rebuilt extension.wasm"
 else
     echo "Warning: cargo not found, skipping WASM rebuild. You must rebuild manually before committing."

--- a/tools/dev/update_version.sh
+++ b/tools/dev/update_version.sh
@@ -98,7 +98,9 @@ update_manifest_release_version() {
 
 validate_release_version_format() {
     local version="$1"
-    local semver_regex='^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
+    # Strict SemVer 2.0.0: pre-release starts with '-' and build metadata with '+',
+    # both composed of dot-separated identifiers of [0-9A-Za-z-].
+    local semver_regex='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
 
     if [[ ! "$version" =~ $semver_regex ]]; then
         echo "Error: version '$version' is not a supported semver string" >&2

--- a/tools/dev/update_version.sh
+++ b/tools/dev/update_version.sh
@@ -1,161 +1,257 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
-# Usage: ./update_version.sh [new_version] [--sight-version <version>]
-# If new_version is not provided, it bumps the patch version.
+# Usage: ./tools/dev/update_version.sh [new_version] [--sight-version <version>]
+# If new_version is not provided, the script bumps the Cargo package patch
+# version and keeps extension.toml's top-level release version in sync.
 
-# Ensure we're in the project root
-if [ ! -f "extension.toml" ]; then
-    echo "Error: extension.toml not found. Run this script from the project root."
+usage() {
+    cat <<'EOF'
+Usage: ./tools/dev/update_version.sh [new_version] [--sight-version <version>]
+
+Arguments:
+  new_version              Optional extension release version (for Cargo.toml
+                           [package].version and extension.toml version)
+
+Options:
+  --sight-version <value>  Optional Sight LSP release tag to set in src/lib.rs
+  --help                   Show this help message
+
+Notes:
+  - extension.toml [lib].version is not changed by this script.
+  - extension.toml [lib].version should continue to match Cargo.toml's
+    zed_extension_api dependency.
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    usage
+    exit 0
+fi
+
+if [[ ! -f "Cargo.toml" || ! -f "extension.toml" ]]; then
+    echo "Error: Cargo.toml and extension.toml must both exist. Run this script from the project root." >&2
     exit 1
 fi
 
-CURRENT_VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' extension.toml | head -n 1)
+extract_manifest_release_version() {
+    awk '
+        /^\[/ { exit }
+        /^[[:space:]]*version[[:space:]]*=/ {
+            if (match($0, /"[^"]+"/)) {
+                print substr($0, RSTART + 1, RLENGTH - 2)
+                found = 1
+                exit
+            }
+        }
+        END { if (!found) exit 1 }
+    ' extension.toml
+}
 
-if [ -z "$CURRENT_VERSION" ]; then
-    echo "Error: Failed to extract version from extension.toml" >&2
-    echo "Expected a line like: version = \"0.1.0\"" >&2
-    exit 1
-fi
+extract_cargo_package_version() {
+    awk '
+        /^\[package\][[:space:]]*$/ { in_package = 1; next }
+        /^\[/ { in_package = 0 }
+        in_package && /^[[:space:]]*version[[:space:]]*=/ {
+            if (match($0, /"[^"]+"/)) {
+                print substr($0, RSTART + 1, RLENGTH - 2)
+                found = 1
+                exit
+            }
+        }
+        END { if (!found) exit 1 }
+    ' Cargo.toml
+}
+
+update_cargo_package_version() {
+    local new_version="$1"
+
+    awk -v new_version="$new_version" '
+        /^\[package\][[:space:]]*$/ { in_package = 1 }
+        /^\[/ && $0 !~ /^\[package\][[:space:]]*$/ { in_package = 0 }
+        in_package && /^[[:space:]]*version[[:space:]]*=/ && !updated {
+            sub(/"[^"]+"/, "\"" new_version "\"")
+            updated = 1
+        }
+        { print }
+        END { if (!updated) exit 1 }
+    ' Cargo.toml > Cargo.toml.tmp
+
+    mv Cargo.toml.tmp Cargo.toml
+}
+
+update_manifest_release_version() {
+    local new_version="$1"
+
+    awk -v new_version="$new_version" '
+        /^\[/ { seen_table = 1 }
+        !seen_table && /^[[:space:]]*version[[:space:]]*=/ && !updated {
+            sub(/"[^"]+"/, "\"" new_version "\"")
+            updated = 1
+        }
+        { print }
+        END { if (!updated) exit 1 }
+    ' extension.toml > extension.toml.tmp
+
+    mv extension.toml.tmp extension.toml
+}
+
+validate_release_version_format() {
+    local version="$1"
+    local semver_regex='^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
+
+    if [[ ! "$version" =~ $semver_regex ]]; then
+        echo "Error: version '$version' is not a supported semver string" >&2
+        exit 1
+    fi
+}
 
 NEW_VERSION=""
 SIGHT_VERSION=""
 
-# Parse args
 while [[ $# -gt 0 ]]; do
-  case $1 in
-    --sight-version)
-      if [ -z "$2" ] || [[ "$2" == --* ]]; then
-        echo "Error: --sight-version requires a non-empty value" >&2
-        exit 1
-      fi
-      SIGHT_VERSION="$2"
-      shift 2
-      ;;
-    *)
-      if [ -z "$NEW_VERSION" ]; then
-        NEW_VERSION="$1"
-      else
-        echo "Unknown argument: $1"
-        exit 1
-      fi
-      shift
-      ;;
-  esac
+    case "$1" in
+        --sight-version)
+            if [[ -z "${2:-}" || "${2:-}" == --* ]]; then
+                echo "Error: --sight-version requires a non-empty value" >&2
+                exit 1
+            fi
+            SIGHT_VERSION="$2"
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            if [[ -z "$NEW_VERSION" ]]; then
+                NEW_VERSION="$1"
+            else
+                echo "Error: unknown argument: $1" >&2
+                exit 1
+            fi
+            shift
+            ;;
+    esac
 done
 
-# Run validation checks before making changes
-echo "Running pre-release validation..."
-
-# Validate grammar revision exists
-if ! ./tools/dev/validate.sh --grammar-rev; then
-    echo "Error: Grammar revision validation failed." >&2
+CURRENT_CARGO_VERSION=$(extract_cargo_package_version) || {
+    echo "Error: Failed to extract Cargo.toml [package].version" >&2
     exit 1
+}
+
+CURRENT_EXTENSION_VERSION=$(extract_manifest_release_version) || {
+    echo "Error: Failed to extract extension.toml top-level version" >&2
+    exit 1
+}
+
+echo "Current Cargo.toml [package].version: $CURRENT_CARGO_VERSION"
+echo "Current extension.toml version: $CURRENT_EXTENSION_VERSION"
+
+if [[ -z "$NEW_VERSION" ]]; then
+    if [[ "$CURRENT_CARGO_VERSION" != "$CURRENT_EXTENSION_VERSION" ]]; then
+        echo "Error: release versions are out of sync." >&2
+        echo "  Cargo.toml [package].version: $CURRENT_CARGO_VERSION" >&2
+        echo "  extension.toml version:      $CURRENT_EXTENSION_VERSION" >&2
+        echo "Provide an explicit version to resync them." >&2
+        exit 1
+    fi
+
+    if ! [[ "$CURRENT_CARGO_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        echo "Error: Current Cargo package version '$CURRENT_CARGO_VERSION' is not in MAJOR.MINOR.PATCH format" >&2
+        exit 1
+    fi
+
+    IFS='.' read -r major minor patch <<< "$CURRENT_CARGO_VERSION"
+    NEW_VERSION="${major}.${minor}.$((patch + 1))"
+    echo "Auto-bumping patch version: $CURRENT_CARGO_VERSION -> $NEW_VERSION"
+else
+    validate_release_version_format "$NEW_VERSION"
+    echo "Setting release version to: $NEW_VERSION"
 fi
 
-# Validate LSP version (use new version if provided, otherwise current)
-if [ -n "$SIGHT_VERSION" ]; then
-    # Check if the new sight version release exists
-    echo "Checking if sight release $SIGHT_VERSION exists..."
-    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "https://api.github.com/repos/jbearak/sight/releases/tags/$SIGHT_VERSION")
-    if [ "$HTTP_CODE" != "200" ]; then
-        echo "Error: Sight release $SIGHT_VERSION not found (HTTP $HTTP_CODE)" >&2
+echo "Running pre-bump validation..."
+./tools/dev/validate.sh --grammar-rev --api-version
+
+if [[ -n "$SIGHT_VERSION" ]]; then
+    echo "Checking if Sight release $SIGHT_VERSION exists..."
+    http_code=$(curl -s -o /dev/null -w "%{http_code}" "https://api.github.com/repos/jbearak/sight/releases/tags/$SIGHT_VERSION")
+    if [[ "$http_code" != "200" ]]; then
+        echo "Error: Sight release $SIGHT_VERSION not found (HTTP $http_code)" >&2
         exit 1
     fi
     echo "Sight release $SIGHT_VERSION exists."
 else
-    if ! ./tools/dev/validate.sh --lsp; then
-        echo "Error: LSP validation failed." >&2
-        exit 1
-    fi
+    ./tools/dev/validate.sh --lsp
 fi
 
-# Validate send-to-stata.sh checksum matches installer
 echo "Validating send-to-stata.sh checksum..."
-EXPECTED_SHA=$(grep '^SEND_TO_STATA_SHA256=' tools/send-to-stata/install-macos.sh | sed 's/.*"\([^"]*\)".*/\1/')
-ACTUAL_SHA=$(shasum -a 256 tools/send-to-stata/send-to-stata.sh | cut -d' ' -f1)
-if [ "$EXPECTED_SHA" != "$ACTUAL_SHA" ]; then
+expected_sha=$(grep '^SEND_TO_STATA_SHA256=' tools/send-to-stata/install-macos.sh | sed 's/.*"\([^"]*\)".*/\1/')
+actual_sha=$(shasum -a 256 tools/send-to-stata/send-to-stata.sh | cut -d' ' -f1)
+if [[ "$expected_sha" != "$actual_sha" ]]; then
     echo "Error: send-to-stata.sh checksum mismatch" >&2
-    echo "  Expected: $EXPECTED_SHA" >&2
-    echo "  Actual:   $ACTUAL_SHA" >&2
+    echo "  Expected: $expected_sha" >&2
+    echo "  Actual:   $actual_sha" >&2
     echo "  Run: ./tools/dev/update-send-to-stata-checksum.sh" >&2
     exit 1
 fi
 echo "send-to-stata.sh checksum OK"
 
-# Validate Windows exe checksums match latest release
 echo "Validating Windows exe checksums..."
-EXPECTED_ARM64=$(grep '^\$expectedChecksumArm64' tools/send-to-stata/install-windows.ps1 | sed 's/.*"\([^"]*\)".*/\1/')
-EXPECTED_X64=$(grep '^\$expectedChecksumX64' tools/send-to-stata/install-windows.ps1 | sed 's/.*"\([^"]*\)".*/\1/')
-ACTUAL_ARM64=$(curl -sL "https://github.com/jbearak/send-to-stata/releases/latest/download/send-to-stata-arm64.exe" | shasum -a 256 | cut -d' ' -f1)
-ACTUAL_X64=$(curl -sL "https://github.com/jbearak/send-to-stata/releases/latest/download/send-to-stata-x64.exe" | shasum -a 256 | cut -d' ' -f1)
-if [ "$EXPECTED_ARM64" != "$ACTUAL_ARM64" ]; then
+expected_arm64=$(grep '^\$expectedChecksumArm64' tools/send-to-stata/install-windows.ps1 | sed 's/.*"\([^"]*\)".*/\1/')
+expected_x64=$(grep '^\$expectedChecksumX64' tools/send-to-stata/install-windows.ps1 | sed 's/.*"\([^"]*\)".*/\1/')
+actual_arm64=$(curl -sL "https://github.com/jbearak/send-to-stata/releases/latest/download/send-to-stata-arm64.exe" | shasum -a 256 | cut -d' ' -f1)
+actual_x64=$(curl -sL "https://github.com/jbearak/send-to-stata/releases/latest/download/send-to-stata-x64.exe" | shasum -a 256 | cut -d' ' -f1)
+if [[ "$expected_arm64" != "$actual_arm64" ]]; then
     echo "Error: send-to-stata-arm64.exe checksum mismatch" >&2
-    echo "  Expected: $EXPECTED_ARM64" >&2
-    echo "  Actual:   $ACTUAL_ARM64" >&2
+    echo "  Expected: $expected_arm64" >&2
+    echo "  Actual:   $actual_arm64" >&2
     echo "  Run the update-send-to-stata GitHub Action to update checksums" >&2
     exit 1
 fi
-if [ "$EXPECTED_X64" != "$ACTUAL_X64" ]; then
+if [[ "$expected_x64" != "$actual_x64" ]]; then
     echo "Error: send-to-stata-x64.exe checksum mismatch" >&2
-    echo "  Expected: $EXPECTED_X64" >&2
-    echo "  Actual:   $ACTUAL_X64" >&2
+    echo "  Expected: $expected_x64" >&2
+    echo "  Actual:   $actual_x64" >&2
     echo "  Run the update-send-to-stata GitHub Action to update checksums" >&2
     exit 1
 fi
 echo "Windows exe checksums OK"
 
-echo "Validation passed."
-echo ""
+update_cargo_package_version "$NEW_VERSION"
+echo "Updated Cargo.toml [package].version to $NEW_VERSION"
 
-if [ -z "$NEW_VERSION" ]; then
-    # Validate semantic version format
-    if ! [[ "$CURRENT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-        echo "Error: Current version '$CURRENT_VERSION' is not in MAJOR.MINOR.PATCH format" >&2
-        exit 1
-    fi
-    
-    # Auto-increment patch
-    IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
-    NEW_PATCH=$((PATCH + 1))
-    NEW_VERSION="$MAJOR.$MINOR.$NEW_PATCH"
-    echo "Auto-bumping patch version: $CURRENT_VERSION -> $NEW_VERSION"
-else
-    echo "Setting version to: $NEW_VERSION"
-fi
+update_manifest_release_version "$NEW_VERSION"
+echo "Updated extension.toml version to $NEW_VERSION"
 
-# Update Cargo.toml
-# Use a temporary file for sed compatibility on both macOS and Linux
-sed "s/^version = \"[^\"]*\"/version = \"$NEW_VERSION\"/" Cargo.toml > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
-echo "Updated Cargo.toml to $NEW_VERSION"
-
-# Update extension.toml
-sed "s/^version = \"[^\"]*\"/version = \"$NEW_VERSION\"/" extension.toml > extension.toml.tmp && mv extension.toml.tmp extension.toml
-echo "Updated extension.toml to $NEW_VERSION"
-
-if [ -n "$SIGHT_VERSION" ]; then
+if [[ -n "$SIGHT_VERSION" ]]; then
     echo "Updating SERVER_VERSION to $SIGHT_VERSION"
-    sed "s/const SERVER_VERSION: \&str = \"[^\"]*\"/const SERVER_VERSION: \\&str = \"$SIGHT_VERSION\"/" src/lib.rs > src/lib.rs.tmp && mv src/lib.rs.tmp src/lib.rs
+    sed "s/const SERVER_VERSION: \&str = \"[^\"]*\"/const SERVER_VERSION: \\&str = \"$SIGHT_VERSION\"/" src/lib.rs > src/lib.rs.tmp
+    mv src/lib.rs.tmp src/lib.rs
 fi
 
-# Rebuild WASM extension if cargo is available
-if command -v cargo &> /dev/null; then
+echo "Running post-bump validation..."
+./tools/dev/validate.sh --release-version --api-version
+if [[ -n "$SIGHT_VERSION" ]]; then
+    ./tools/dev/validate.sh --lsp
+fi
+
+if command -v cargo >/dev/null 2>&1; then
     echo "Rebuilding WASM extension..."
     cargo build --release --target wasm32-wasip1
     cp target/wasm32-wasip1/release/zed_stata.wasm extension.wasm
     echo "Rebuilt extension.wasm"
 else
-    echo "Warning: cargo not found, skipping WASM rebuild. You must rebuild manually before committing."
+    echo "Error: cargo not found; cannot rebuild extension.wasm" >&2
     exit 1
 fi
 
-# Commit the changes
-FILES_TO_COMMIT="Cargo.toml extension.toml"
-if [ -n "$SIGHT_VERSION" ]; then
-    FILES_TO_COMMIT="$FILES_TO_COMMIT src/lib.rs"
+files_to_commit=(Cargo.toml extension.toml extension.wasm)
+if [[ -n "$SIGHT_VERSION" ]]; then
+    files_to_commit+=(src/lib.rs)
 fi
 
-git add -f $FILES_TO_COMMIT
+git add -f "${files_to_commit[@]}"
 git commit -m "Bump version to $NEW_VERSION"
 git tag "v$NEW_VERSION"
 echo "Committed and tagged v$NEW_VERSION"

--- a/tools/dev/validate.sh
+++ b/tools/dev/validate.sh
@@ -11,6 +11,7 @@
 #   --all           Run all validations (default)
 #   --lsp           Validate LSP release exists with required assets
 #   --grammar-rev   Validate grammar revision exists
+#   --release-version Validate extension.toml version matches Cargo.toml [package].version
 #   --api-version   Validate extension.toml [lib].version matches Cargo.toml zed_extension_api
 #   --build         Build extension WASM
 #   --grammar-build Build grammar from specified revision
@@ -79,6 +80,7 @@ Options:
   --all           Run all validations (default if no options specified)
   --lsp           Validate LSP release exists with required assets
   --grammar-rev   Validate grammar revision exists
+  --release-version Validate extension.toml version matches Cargo.toml [package].version
   --api-version   Validate extension.toml [lib].version matches Cargo.toml zed_extension_api
   --build         Build extension WASM
   --grammar-build Build grammar from specified revision
@@ -90,6 +92,7 @@ Environment Variables:
 Examples:
   ./validate.sh                 # Run all validations
   ./validate.sh --lsp           # Only check LSP release
+  ./validate.sh --release-version # Only check release-version alignment
   ./validate.sh --api-version   # Only check manifest/API version alignment
   ./validate.sh --build         # Only build extension WASM
   ./validate.sh --lsp --build   # Check LSP and build extension
@@ -168,6 +171,37 @@ extract_grammar_revision() {
     echo "$revision"
 }
 
+# Extract top-level extension.toml version.
+# Output: Release version string (e.g., "0.5.0")
+extract_manifest_release_version() {
+    local extension_toml="${REPO_ROOT}/extension.toml"
+
+    if [[ ! -f "$extension_toml" ]]; then
+        echo "ERROR: File not found: $extension_toml" >&2
+        return 1
+    fi
+
+    local version
+    version=$(awk '
+        /^\[/ { exit }
+        /^[[:space:]]*version[[:space:]]*=/ {
+            if (match($0, /"[^"]+"/)) {
+                print substr($0, RSTART + 1, RLENGTH - 2)
+                found = 1
+                exit
+            }
+        }
+        END { if (!found) exit 1 }
+    ' "$extension_toml" 2>/dev/null || true)
+
+    if [[ -z "$version" ]]; then
+        echo "ERROR: top-level version not found in $extension_toml" >&2
+        return 1
+    fi
+
+    echo "$version"
+}
+
 # Extract [lib].version from extension.toml
 # Output: API version string (e.g., "0.7.0")
 extract_manifest_lib_version() {
@@ -194,6 +228,38 @@ extract_manifest_lib_version() {
 
     if [[ -z "$version" ]]; then
         echo "ERROR: [lib] version not found in $extension_toml" >&2
+        return 1
+    fi
+
+    echo "$version"
+}
+
+# Extract Cargo.toml [package].version
+# Output: Release version string (e.g., "0.5.0")
+extract_cargo_package_version() {
+    local cargo_toml="${REPO_ROOT}/Cargo.toml"
+
+    if [[ ! -f "$cargo_toml" ]]; then
+        echo "ERROR: File not found: $cargo_toml" >&2
+        return 1
+    fi
+
+    local version
+    version=$(awk '
+        /^\[package\][[:space:]]*$/ { in_package = 1; next }
+        /^\[/ { in_package = 0 }
+        in_package && /^[[:space:]]*version[[:space:]]*=/ {
+            if (match($0, /"[^"]+"/)) {
+                print substr($0, RSTART + 1, RLENGTH - 2)
+                found = 1
+                exit
+            }
+        }
+        END { if (!found) exit 1 }
+    ' "$cargo_toml" 2>/dev/null || true)
+
+    if [[ -z "$version" ]]; then
+        echo "ERROR: [package] version not found in $cargo_toml" >&2
         return 1
     fi
 
@@ -254,6 +320,39 @@ normalize_version() {
     else
         echo "v${version}"
     fi
+}
+
+#######################################
+# Release Version Validator
+#######################################
+
+# Validate extension.toml version matches Cargo.toml [package].version
+# Arguments:
+#   $1 - Optional manifest release version
+#   $2 - Optional Cargo package version
+# Returns: 0 on success, 1 on failure
+validate_release_version_alignment() {
+    local manifest_version="${1:-}"
+    local cargo_version="${2:-}"
+
+    if [[ -z "$manifest_version" ]]; then
+        manifest_version=$(extract_manifest_release_version) || return 1
+    fi
+
+    if [[ -z "$cargo_version" ]]; then
+        cargo_version=$(extract_cargo_package_version) || return 1
+    fi
+
+    print_info "Checking release version alignment..."
+
+    if [[ "$manifest_version" != "$cargo_version" ]]; then
+        print_fail "extension.toml version is $manifest_version but Cargo.toml [package].version is $cargo_version"
+        echo "  Update these release-version fields together."
+        return 1
+    fi
+
+    print_pass "Release versions are aligned: $manifest_version"
+    return 0
 }
 
 #######################################
@@ -559,6 +658,7 @@ main() {
     local run_all=false
     local run_lsp=false
     local run_grammar_rev=false
+    local run_release_version=false
     local run_api_version=false
     local run_build=false
     local run_grammar_build=false
@@ -579,6 +679,10 @@ main() {
                     ;;
                 --grammar-rev)
                     run_grammar_rev=true
+                    shift
+                    ;;
+                --release-version)
+                    run_release_version=true
                     shift
                     ;;
                 --api-version)
@@ -610,6 +714,7 @@ main() {
     if [[ "$run_all" == true ]]; then
         run_lsp=true
         run_grammar_rev=true
+        run_release_version=true
         run_api_version=true
         run_build=true
         run_grammar_build=true
@@ -623,6 +728,8 @@ main() {
     # Extract configuration
     local server_version=""
     local grammar_revision=""
+    local manifest_release_version=""
+    local cargo_package_version=""
     local manifest_lib_version=""
     local cargo_api_version=""
     
@@ -641,6 +748,22 @@ main() {
             record_result 1 "Failed to extract grammar revision"
         else
             print_info "Grammar revision: $grammar_revision"
+        fi
+    fi
+
+    if [[ "$run_release_version" == true ]]; then
+        print_info "Extracting top-level version from extension.toml..."
+        if ! manifest_release_version=$(extract_manifest_release_version); then
+            record_result 1 "Failed to extract extension.toml version"
+        else
+            print_info "Manifest version: $manifest_release_version"
+        fi
+
+        print_info "Extracting [package] version from Cargo.toml..."
+        if ! cargo_package_version=$(extract_cargo_package_version); then
+            record_result 1 "Failed to extract Cargo.toml [package] version"
+        else
+            print_info "Cargo package version: $cargo_package_version"
         fi
     fi
 
@@ -679,6 +802,16 @@ main() {
             record_result 0 "Grammar revision validation"
         else
             record_result 1 "Grammar revision validation"
+        fi
+        echo ""
+    fi
+
+    if [[ "$run_release_version" == true && -n "$manifest_release_version" && -n "$cargo_package_version" ]]; then
+        echo "--- Release Version Validation ---"
+        if validate_release_version_alignment "$manifest_release_version" "$cargo_package_version"; then
+            record_result 0 "Release version validation"
+        else
+            record_result 1 "Release version validation"
         fi
         echo ""
     fi

--- a/tools/dev/validate.sh
+++ b/tools/dev/validate.sh
@@ -11,6 +11,7 @@
 #   --all           Run all validations (default)
 #   --lsp           Validate LSP release exists with required assets
 #   --grammar-rev   Validate grammar revision exists
+#   --api-version   Validate extension.toml [lib].version matches Cargo.toml zed_extension_api
 #   --build         Build extension WASM
 #   --grammar-build Build grammar from specified revision
 #   --help          Show this help message
@@ -78,6 +79,7 @@ Options:
   --all           Run all validations (default if no options specified)
   --lsp           Validate LSP release exists with required assets
   --grammar-rev   Validate grammar revision exists
+  --api-version   Validate extension.toml [lib].version matches Cargo.toml zed_extension_api
   --build         Build extension WASM
   --grammar-build Build grammar from specified revision
   --help          Show this help message
@@ -88,6 +90,7 @@ Environment Variables:
 Examples:
   ./validate.sh                 # Run all validations
   ./validate.sh --lsp           # Only check LSP release
+  ./validate.sh --api-version   # Only check manifest/API version alignment
   ./validate.sh --build         # Only build extension WASM
   ./validate.sh --lsp --build   # Check LSP and build extension
 
@@ -165,6 +168,70 @@ extract_grammar_revision() {
     echo "$revision"
 }
 
+# Extract [lib].version from extension.toml
+# Output: API version string (e.g., "0.7.0")
+extract_manifest_lib_version() {
+    local extension_toml="${REPO_ROOT}/extension.toml"
+
+    if [[ ! -f "$extension_toml" ]]; then
+        echo "ERROR: File not found: $extension_toml" >&2
+        return 1
+    fi
+
+    local version
+    version=$(awk '
+        /^\[lib\][[:space:]]*$/ { in_lib = 1; next }
+        /^\[/ { in_lib = 0 }
+        in_lib && /^[[:space:]]*version[[:space:]]*=/ {
+            if (match($0, /"[^"]+"/)) {
+                print substr($0, RSTART + 1, RLENGTH - 2)
+                found = 1
+                exit
+            }
+        }
+        END { if (!found) exit 1 }
+    ' "$extension_toml" 2>/dev/null || true)
+
+    if [[ -z "$version" ]]; then
+        echo "ERROR: [lib] version not found in $extension_toml" >&2
+        return 1
+    fi
+
+    echo "$version"
+}
+
+# Extract zed_extension_api dependency version from Cargo.toml
+# Output: API version string (e.g., "0.7.0")
+extract_zed_extension_api_version() {
+    local cargo_toml="${REPO_ROOT}/Cargo.toml"
+
+    if [[ ! -f "$cargo_toml" ]]; then
+        echo "ERROR: File not found: $cargo_toml" >&2
+        return 1
+    fi
+
+    local version
+    version=$(awk '
+        /^\[dependencies\][[:space:]]*$/ { in_dependencies = 1; next }
+        /^\[/ { in_dependencies = 0 }
+        in_dependencies && /^[[:space:]]*zed_extension_api[[:space:]]*=/ {
+            if (match($0, /"[^"]+"/)) {
+                print substr($0, RSTART + 1, RLENGTH - 2)
+                found = 1
+                exit
+            }
+        }
+        END { if (!found) exit 1 }
+    ' "$cargo_toml" 2>/dev/null || true)
+
+    if [[ -z "$version" ]]; then
+        echo "ERROR: zed_extension_api dependency not found in $cargo_toml" >&2
+        return 1
+    fi
+
+    echo "$version"
+}
+
 
 
 #######################################
@@ -187,6 +254,39 @@ normalize_version() {
     else
         echo "v${version}"
     fi
+}
+
+#######################################
+# Extension API Version Validator
+#######################################
+
+# Validate extension.toml [lib].version matches Cargo.toml zed_extension_api
+# Arguments:
+#   $1 - Optional manifest lib version
+#   $2 - Optional Cargo zed_extension_api version
+# Returns: 0 on success, 1 on failure
+validate_api_version_alignment() {
+    local manifest_version="${1:-}"
+    local cargo_version="${2:-}"
+
+    if [[ -z "$manifest_version" ]]; then
+        manifest_version=$(extract_manifest_lib_version) || return 1
+    fi
+
+    if [[ -z "$cargo_version" ]]; then
+        cargo_version=$(extract_zed_extension_api_version) || return 1
+    fi
+
+    print_info "Checking extension API version alignment..."
+
+    if [[ "$manifest_version" != "$cargo_version" ]]; then
+        print_fail "extension.toml [lib].version is $manifest_version but Cargo.toml zed_extension_api is $cargo_version"
+        echo "  Update extension.toml [lib].version when bumping zed_extension_api."
+        return 1
+    fi
+
+    print_pass "API versions are aligned: $manifest_version"
+    return 0
 }
 
 #######################################
@@ -459,6 +559,7 @@ main() {
     local run_all=false
     local run_lsp=false
     local run_grammar_rev=false
+    local run_api_version=false
     local run_build=false
     local run_grammar_build=false
     
@@ -478,6 +579,10 @@ main() {
                     ;;
                 --grammar-rev)
                     run_grammar_rev=true
+                    shift
+                    ;;
+                --api-version)
+                    run_api_version=true
                     shift
                     ;;
                 --build)
@@ -505,6 +610,7 @@ main() {
     if [[ "$run_all" == true ]]; then
         run_lsp=true
         run_grammar_rev=true
+        run_api_version=true
         run_build=true
         run_grammar_build=true
     fi
@@ -517,6 +623,8 @@ main() {
     # Extract configuration
     local server_version=""
     local grammar_revision=""
+    local manifest_lib_version=""
+    local cargo_api_version=""
     
     if [[ "$run_lsp" == true || "$run_build" == true ]]; then
         print_info "Extracting server version from src/lib.rs..."
@@ -533,6 +641,22 @@ main() {
             record_result 1 "Failed to extract grammar revision"
         else
             print_info "Grammar revision: $grammar_revision"
+        fi
+    fi
+
+    if [[ "$run_api_version" == true ]]; then
+        print_info "Extracting [lib] version from extension.toml..."
+        if ! manifest_lib_version=$(extract_manifest_lib_version); then
+            record_result 1 "Failed to extract extension.toml [lib] version"
+        else
+            print_info "Manifest [lib] version: $manifest_lib_version"
+        fi
+
+        print_info "Extracting zed_extension_api version from Cargo.toml..."
+        if ! cargo_api_version=$(extract_zed_extension_api_version); then
+            record_result 1 "Failed to extract Cargo.toml zed_extension_api version"
+        else
+            print_info "Cargo zed_extension_api version: $cargo_api_version"
         fi
     fi
     
@@ -558,7 +682,17 @@ main() {
         fi
         echo ""
     fi
-    
+
+    if [[ "$run_api_version" == true && -n "$manifest_lib_version" && -n "$cargo_api_version" ]]; then
+        echo "--- Extension API Version Validation ---"
+        if validate_api_version_alignment "$manifest_lib_version" "$cargo_api_version"; then
+            record_result 0 "Extension API version validation"
+        else
+            record_result 1 "Extension API version validation"
+        fi
+        echo ""
+    fi
+
     if [[ "$run_build" == true ]]; then
         echo "--- Extension Build Validation ---"
         if validate_extension_build; then

--- a/tools/dev/validate.sh
+++ b/tools/dev/validate.sh
@@ -353,7 +353,7 @@ validate_extension_build() {
     fi
     
     # Check for output file
-    local wasm_file="${REPO_ROOT}/target/wasm32-wasip1/release/sight_extension.wasm"
+    local wasm_file="${REPO_ROOT}/target/wasm32-wasip1/release/zed_stata.wasm"
     if [[ ! -f "$wasm_file" ]]; then
         print_fail "WASM output file not found: $wasm_file"
         return 1

--- a/tools/dev/validate.sh
+++ b/tools/dev/validate.sh
@@ -2,7 +2,7 @@
 #
 # validate.sh - Extension Build Validation Suite
 #
-# Validates that the Sight Zed extension can build successfully with its
+# Validates that the Stata Zed extension can build successfully with its
 # specified LSP and tree-sitter grammar revisions.
 #
 # Usage: ./validate.sh [OPTIONS]

--- a/tools/dev/validate.sh
+++ b/tools/dev/validate.sh
@@ -69,7 +69,7 @@ show_help() {
     cat << EOF
 Extension Build Validation Suite
 
-Validates that the Sight Zed extension can build successfully with its
+Validates that the Stata Zed extension can build successfully with its
 specified LSP and tree-sitter grammar revisions.
 
 Usage: ./validate.sh [OPTIONS]

--- a/verify-jupyter.ps1
+++ b/verify-jupyter.ps1
@@ -119,9 +119,9 @@ try {
 
 # Check 5: Zed extension
 Write-Section "Zed Extension Configuration"
-$extPath = "$env:LOCALAPPDATA\Zed\extensions\installed\sight"
+$extPath = "$env:LOCALAPPDATA\Zed\extensions\installed\stata"
 if (Test-Path $extPath) {
-    Write-Check "Sight extension is installed" $true
+    Write-Check "Stata extension is installed" $true
     Write-Host "    Location: $extPath" -ForegroundColor Gray
 
     # Check config.toml
@@ -142,7 +142,7 @@ if (Test-Path $extPath) {
         Write-Check "config.toml NOT found" $false
     }
 } else {
-    Write-Check "Sight extension NOT installed" $false
+    Write-Check "Stata extension NOT installed" $false
 }
 
 # Check 6: Zed process


### PR DESCRIPTION
## Summary
- Renames the extension package and install paths from `sight` to `stata`.
- Updates user-facing copy, dev scripts, validation helpers, and Windows/macOS install locations to use Stata terminology.
- Adjusts test fixtures and configuration parsing expectations to match the new extension identity.

## Testing
- Not run.
- Checked the diff for consistent path and name updates across scripts, docs, and tests.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/zed-stata/pull/43" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Rebranded the extension from "Sight" to "Stata" across UI text and install locations on macOS, Linux, and Windows.
  * Bumped extension release version to 0.5.0 (library/API version updated accordingly) and updated installation/build artifact names.
  * Strengthened release/version handling with added checks to ensure release and API versions remain aligned during dev/release workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->