### PR TITLE
Update tree-sitter-stata grammar to v0.1.2

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -16,7 +16,7 @@ version = "0.7.0"
 
 [grammars.stata]
 repository = "https://github.com/jbearak/tree-sitter-stata"
-rev = "f4679d8dbd274828052b1e0c2ba1383b78853865"
+rev = "e68719f9d3c814ef240bdfd655aea4d9eb6848ad"
 
 [language_servers.sight]
 name = "Sight"

--- a/tools/dev/dev-setup-windows.ps1
+++ b/tools/dev/dev-setup-windows.ps1
@@ -75,8 +75,8 @@ $script:Checksums = @{
     # WASI SDK 24 - x86_64 Windows (ARM64 Windows not available in this release)
     WasiSdkX64 = "0f934c6e7e171b5627c81b697a9e57e96d65cd889f56ce6077350de48978afd3"
 
-    # Tree-sitter-stata grammar WASM v0.1.1
-    TreeSitterGrammar = "203db5c3640576479a04c7f68205d23fe1868fce370e2c76604c7c701aae5737"
+    # Tree-sitter-stata grammar WASM v0.1.2
+    TreeSitterGrammar = "62b5a84c063bfdca96bcdfe98c7e18d831b3a24191d4dc321932628370325e3a"
 
     # Sight language server v0.7.1
     SightServer = "014aadf670592281fd7cda3eafb6a013d70ee7cde419c984d9dc4eee27a9ccc6"
@@ -574,7 +574,7 @@ function Download-TreeSitterGrammar {
     # Pin to a known grammar release so the downloaded wasm matches the rev pinned
     # in extension.toml and so we can verify its checksum. Bump this (and the
     # TreeSitterGrammar checksum above) when updating the grammar.
-    $grammarVersion = "v0.1.1"
+    $grammarVersion = "v0.1.2"
 
     $grammarUrl = "https://github.com/jbearak/tree-sitter-stata/releases/download/$grammarVersion/tree-sitter-stata.wasm"
 

--- a/tools/dev/update-dev-checksums.ps1
+++ b/tools/dev/update-dev-checksums.ps1
@@ -48,7 +48,7 @@ try {
     Write-Host "  WASI SDK x64: $wasiSdkHash" -ForegroundColor Green
 
     # Tree-sitter-stata grammar
-    $grammarUrl = "https://github.com/jbearak/tree-sitter-stata/releases/download/v0.1.1/tree-sitter-stata.wasm"
+    $grammarUrl = "https://github.com/jbearak/tree-sitter-stata/releases/download/v0.1.2/tree-sitter-stata.wasm"
     $grammarPath = Join-Path $tempDir "stata.wasm"
     
     Write-Host "Downloading tree-sitter-stata grammar..." -ForegroundColor Yellow


### PR DESCRIPTION
## Summary
- Update the tree-sitter-stata grammar source revision to the `v0.1.2` release commit.
- Update Windows local-dev grammar download metadata to fetch the `v0.1.2` prebuilt WASM.
- Update the Windows checksum updater to use the matching `v0.1.2` release asset.

## Verification
- `./tools/dev/validate.sh --grammar-rev`
- `./tools/dev/validate.sh --grammar-build`
- PowerShell AST parse for `tools/dev/dev-setup-windows.ps1` and `tools/dev/update-dev-checksums.ps1`
- `git diff --check HEAD~1..HEAD`

## Notes
- The `v0.1.2` prebuilt WASM is published by `jbearak/tree-sitter-stata`; this repo only pins and verifies the release asset for Windows local dev.

Closes #55 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Stata language grammar and parser to the latest version for improved syntax support and code recognition capabilities
  * Updated development environment setup scripts and checksums for consistency across development platforms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->