### PR TITLE
Fix file-extension mis-highlighting in file commands (grammar v0.2.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,24 +137,65 @@ To uninstall including config:
 
 ## Updating the Tree-Sitter Grammar
 
-When the tree-sitter-stata grammar is updated:
+The grammar lives in a **separate repo** (`jbearak/tree-sitter-stata`) and is
+pinned here by commit SHA. For the marketplace and `zed: install dev extension`,
+Zed fetches that `rev` and compiles the grammar to WASM from source. **Windows
+local dev cannot compile grammars**, so it instead downloads a pre-built
+`tree-sitter-stata.wasm` from the matching GitHub *release* (checksum-verified).
+macOS/Linux dev (`tools/dev/dev-setup-macos.sh`) builds the grammar from source,
+so it has nothing to pin.
 
-1. Edit `extension.toml`
-2. Update the `rev` field under `[grammars.stata]` to the new commit SHA
-3. The grammar is fetched from `https://github.com/jbearak/tree-sitter-stata`
+Follow these steps **in order** whenever the grammar changes. The current pinned
+release is **v0.2.0**.
 
-For the marketplace (and `zed: install dev extension`), Zed fetches that `rev`
-and compiles the grammar to WASM from source. Windows local dev cannot compile
-grammars, so it instead downloads a pre-built `tree-sitter-stata.wasm` from the
-matching GitHub release. When bumping the grammar, also update the pinned Windows
-download so the two stay in sync:
+### 1. Release the grammar (in the `tree-sitter-stata` repo)
 
-- `tools/dev/dev-setup-windows.ps1`: `$grammarVersion` (currently `v0.1.1`) and
-  the `TreeSitterGrammar` checksum
+1. Make the grammar change; regenerate and test: `tree-sitter generate` then
+   `tree-sitter test` (both need the sandbox disabled — they require a writable
+   tree-sitter cache lock), plus `bun test` (run `bun install` first).
+2. Bump the version in **all four** files: `package.json`, `Cargo.toml`,
+   `tree-sitter.json` (`metadata.version`), and `Cargo.lock`.
+3. **Regenerate `parser.c` after the version bump** and commit it. The grammar
+   version is embedded in `parser.c` (`.metadata.minor_version`); the release CI
+   runs `tree-sitter generate` then `git diff --exit-code src/parser.c`, so a
+   bumped `tree-sitter.json` with a stale `parser.c` fails CI.
+4. Commit, tag `vX.Y.Z`, push `main` and the tag. The tag triggers
+   `release.yml`, which publishes `tree-sitter-stata.wasm` and
+   `tree-sitter-stata.tar.gz` to the GitHub release. **Wait for this release to
+   succeed** — step 3 below downloads that wasm.
+
+### 2. Point this extension at the new grammar
+
+1. `extension.toml`: update `rev` under `[grammars.stata]` to the new commit SHA.
+2. Update `languages/stata/highlights.scm` (and other `languages/stata/*.scm`
+   queries) if node types changed.
+
+### 3. Update the pinned Windows pre-built grammar (must match the new release)
+
+All three must point at the same release tag, and the checksum must match that
+release's `tree-sitter-stata.wasm`:
+
+- `tools/dev/dev-setup-windows.ps1`: `$grammarVersion` **and** the
+  `TreeSitterGrammar` SHA-256 checksum
 - `tools/dev/update-dev-checksums.ps1`: the `$grammarUrl` release tag
+- `install-grammar.ps1`: the `$grammarUrl` release tag (quick helper; no checksum)
 
-Run `pwsh -File tools/dev/update-dev-checksums.ps1` to recompute the checksum
-after bumping the tag.
+Then recompute and write the checksum with:
+
+```
+pwsh -File tools/dev/update-dev-checksums.ps1
+```
+
+(Requires the release's `tree-sitter-stata.wasm` to exist first. The script reads
+`$grammarUrl` from itself, downloads the wasm, and rewrites the
+`TreeSitterGrammar` checksum in `dev-setup-windows.ps1`.)
+
+### 4. Verify
+
+- `tools/dev/validate.sh --grammar-rev` — confirms the `rev` in `extension.toml`
+  exists upstream.
+- Bump any docs that name the pinned tag: this section, the "How the pre-built
+  grammar is consumed" note below, and `tools/dev/README.md`.
 
 ## Language Server Configuration Gotcha
 
@@ -306,7 +347,7 @@ The grammar WASM is:
 1. Built on macOS/Linux using the WASI SDK
 2. Published to tree-sitter-stata releases as `tree-sitter-stata.wasm`
 3. Downloaded by `tools/dev/dev-setup-windows.ps1` — pinned to a known release tag
-   (currently `v0.1.1`) and checksum-verified — and placed in `grammars/stata.wasm`
+   (currently `v0.2.0`) and checksum-verified — and placed in `grammars/stata.wasm`
 4. Loaded by Zed from the installed-extension layout at runtime
 
 **How the pre-built grammar is consumed**: `extension.toml` references the grammar

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/extension.toml
+++ b/extension.toml
@@ -16,7 +16,7 @@ version = "0.7.0"
 
 [grammars.stata]
 repository = "https://github.com/jbearak/tree-sitter-stata"
-rev = "e68719f9d3c814ef240bdfd655aea4d9eb6848ad"
+rev = "a47d1bb771d45da5058953f5d935759fac16d854"
 
 [language_servers.sight]
 name = "Sight"

--- a/install-grammar.ps1
+++ b/install-grammar.ps1
@@ -16,7 +16,7 @@ param()
 
 $ErrorActionPreference = 'Stop'
 
-$grammarUrl = "https://github.com/jbearak/tree-sitter-stata/releases/download/v0.1.1/tree-sitter-stata.wasm"
+$grammarUrl = "https://github.com/jbearak/tree-sitter-stata/releases/download/v0.2.0/tree-sitter-stata.wasm"
 
 # Download to project grammars directory
 $grammarsDir = Join-Path $PSScriptRoot 'grammars'

--- a/languages/stata/highlights.scm
+++ b/languages/stata/highlights.scm
@@ -68,7 +68,10 @@
 
 ; Additional keywords parsed as identifiers
 ((identifier) @keyword
-  (#match? @keyword "^(in|using|do|run|include)$"))
+  (#match? @keyword "^(in|do|run|include)$"))
+
+; `using` keyword (introduces a file path in many commands)
+"using" @keyword
 
 ; =============================================================================
 ; TYPES
@@ -87,6 +90,10 @@
 
 ; Generic command names
 (command
+  name: (identifier) @function)
+
+; File command names (use, save, do, import, cd, erase, ...)
+(file_command
   name: (identifier) @function)
 
 ; =============================================================================
@@ -109,6 +116,9 @@
 
 ; Missing values
 (missing_value) @constant
+
+; File paths / filenames (arguments to file commands and `using` clauses)
+(file_path) @string.special.path
 
 ; =============================================================================
 ; OPERATORS

--- a/tools/dev/README.md
+++ b/tools/dev/README.md
@@ -72,7 +72,7 @@ This will:
 2. Build the extension WASM (`extension.wasm`)
 3. Download pre-built tree-sitter grammar (Windows cannot compile grammars) from
    the [tree-sitter-stata releases](https://github.com/jbearak/tree-sitter-stata/releases),
-   pinned to a known tag (currently `v0.1.1`) and checksum-verified
+   pinned to a known tag (currently `v0.2.0`) and checksum-verified
 4. Download the language server for dev testing
 5. Copy extension files to Zed's extensions directory
 6. Install Send-to-Stata integration
@@ -125,7 +125,7 @@ copy target\wasm32-wasip2\release\zed_stata.wasm extension.wasm
 
 # Grammar must be downloaded (Windows cannot compile tree-sitter grammars).
 # dev-setup-windows.ps1 fetches the pre-built grammars/stata.wasm from
-# https://github.com/jbearak/tree-sitter-stata/releases (pinned to v0.1.1,
+# https://github.com/jbearak/tree-sitter-stata/releases (pinned to v0.2.0,
 # checksum-verified) and removes any grammars/stata/ source dir so Zed won't
 # try to compile it.
 ```

--- a/tools/dev/dev-setup-windows.ps1
+++ b/tools/dev/dev-setup-windows.ps1
@@ -75,8 +75,8 @@ $script:Checksums = @{
     # WASI SDK 24 - x86_64 Windows (ARM64 Windows not available in this release)
     WasiSdkX64 = "0f934c6e7e171b5627c81b697a9e57e96d65cd889f56ce6077350de48978afd3"
 
-    # Tree-sitter-stata grammar WASM v0.1.2
-    TreeSitterGrammar = "62b5a84c063bfdca96bcdfe98c7e18d831b3a24191d4dc321932628370325e3a"
+    # Tree-sitter-stata grammar WASM v0.2.0
+    TreeSitterGrammar = "a411fbcb8e6fe236bac2c4631f802185773f9f73ef1cfc78e29606042731b261"
 
     # Sight language server v0.8.0
     SightServer = "0b65a61abbe9d7cddbf5fc749e8bfb2328f66960902e50ea8c631db92c9103c6"
@@ -574,7 +574,7 @@ function Download-TreeSitterGrammar {
     # Pin to a known grammar release so the downloaded wasm matches the rev pinned
     # in extension.toml and so we can verify its checksum. Bump this (and the
     # TreeSitterGrammar checksum above) when updating the grammar.
-    $grammarVersion = "v0.1.2"
+    $grammarVersion = "v0.2.0"
 
     $grammarUrl = "https://github.com/jbearak/tree-sitter-stata/releases/download/$grammarVersion/tree-sitter-stata.wasm"
 

--- a/tools/dev/update-dev-checksums.ps1
+++ b/tools/dev/update-dev-checksums.ps1
@@ -48,7 +48,7 @@ try {
     Write-Host "  WASI SDK x64: $wasiSdkHash" -ForegroundColor Green
 
     # Tree-sitter-stata grammar
-    $grammarUrl = "https://github.com/jbearak/tree-sitter-stata/releases/download/v0.1.2/tree-sitter-stata.wasm"
+    $grammarUrl = "https://github.com/jbearak/tree-sitter-stata/releases/download/v0.2.0/tree-sitter-stata.wasm"
     $grammarPath = Join-Path $tempDir "stata.wasm"
     
     Write-Host "Downloading tree-sitter-stata grammar..." -ForegroundColor Yellow


### PR DESCRIPTION
## Problem

In `use merp.do` / `use merp.dta` (and other file commands), the `.d` of the
extension was highlighted as a `@constant`. The grammar's `missing_value` rule
(`/\.[a-z]?/`, for Stata's `.a`–`.z` extended missing values) greedily ate the
`.d`, so `merp.do` tokenized as `identifier` + `missing_value` + `identifier`.

## Fix (tree-sitter-stata v0.2.0)

A filename and a factor variable are textually identical (`i.dta` could be factor
`i.` of var `dta`, or file `i.dta`), so the new `file_path` token is **lexically
scoped** to filename contexts only — valid exclusively inside the new
`file_command` node and after `using` (`using_clause`, added to every command).
Because `file_path` is never valid in a `regress`/`xtreg` argument position,
factor variables tokenize unchanged — **issue #51 is protected structurally** and
locked by a corpus test.

Grammar work lives in `jbearak/tree-sitter-stata` (released as **v0.2.0**,
commit `a47d1bb`); this PR points the extension at it.

## Changes in this repo

- `extension.toml`: `[grammars.stata]` rev → `a47d1bb` (v0.2.0)
- `languages/stata/highlights.scm`: `file_path` → `@string.special.path`,
  `file_command` name → `@function`, `using` → `@keyword`
- **Windows pre-built grammar pin** (Windows can't compile grammars locally, so it
  downloads a checksum-verified wasm) bumped to v0.2.0 in
  `tools/dev/dev-setup-windows.ps1` (`$grammarVersion` + `TreeSitterGrammar`
  checksum `a411fbcb…`), `tools/dev/update-dev-checksums.ps1`, and
  `install-grammar.ps1`. macOS/Linux build from source — nothing to pin.
- `AGENTS.md`: rewrote "Updating the Tree-Sitter Grammar" as a complete ordered
  checklist; refreshed stale version mentions in `AGENTS.md` / `tools/dev/README.md`.

## Verification

- Grammar: 13/13 corpus tests, 34/34 bun tests; red-green confirmed (reverting the
  grammar fails the 6 new tests, original 7 incl. #51 stay green). v0.2.0 release
  CI green.
- Windows checksum confirmed three ways (shasum, GitHub API digest,
  `update-dev-checksums.ps1 -DryRun`).