### PR TITLE
Update sight to v0.12.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed-stata"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2021"
 license = "GPL-3.0"
 description = "Zed extension for Stata language support"

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "stata"
 name = "Stata"
 description = "Stata language support for Zed"
-version = "0.5.8"
+version = "0.5.9"
 schema_version = 1
 authors = ["Jonathan Marc Bearak"]
 repository = "https://github.com/jbearak/zed-stata"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 use zed_extension_api::{self as zed, DownloadedFileType, Result};
 
-const SERVER_VERSION: &str = "v0.8.0";
+const SERVER_VERSION: &str = "v0.12.0";
 const GITHUB_RELEASE_URL: &str = "https://github.com/jbearak/sight/releases/download";
 
 struct SightExtension {

--- a/tools/dev/dev-setup-windows.ps1
+++ b/tools/dev/dev-setup-windows.ps1
@@ -78,8 +78,8 @@ $script:Checksums = @{
     # Tree-sitter-stata grammar WASM v0.2.0
     TreeSitterGrammar = "a411fbcb8e6fe236bac2c4631f802185773f9f73ef1cfc78e29606042731b261"
 
-    # Sight language server v0.8.0
-    SightServer = "0b65a61abbe9d7cddbf5fc749e8bfb2328f66960902e50ea8c631db92c9103c6"
+    # Sight language server v0.12.0
+    SightServer = "0fa9eb54c516f89f2cbf34084c82018b851f7b9113bb3425ef0b96d5f4d6e7c3"
 }
 
 function Test-FileChecksum {
@@ -632,7 +632,7 @@ function Download-LanguageServerForDev {
     # but downloads go to Zed's work directory. We need to copy/download the server to the repo
     # so it can be found during dev testing.
 
-    $serverVersion = "v0.8.0"
+    $serverVersion = "v0.12.0"
     $serverDir = Join-Path $RepoRoot "sight-node-$serverVersion"
     $serverScript = Join-Path $serverDir "sight-server.js"
 


### PR DESCRIPTION
## Summary

This PR updates the sight language server to **v0.12.0**.

### Changes
- SERVER_VERSION: v0.8.0 -> v0.12.0
- Extension version: 0.5.8 -> 0.5.9
- Verified extension.wasm builds (Zed compiles it from source; not committed)
- Updated dev-setup-windows.ps1 SightServer checksum

### Testing Checklist
- [ ] Install extension in Zed
- [ ] Open a .do file and verify LSP starts
- [ ] Check hover/go-to-definition

---
*Automated PR from update-sight-version workflow.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the package and extension versions to **0.5.9**.
  * Updated the bundled language server to **v0.12.0**, along with its verified download checksum.
  * Improved startup/setup reliability by ensuring the correct server release is used during installation and development setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->